### PR TITLE
feat: mermaid (.mmd) を mmdc でブラウザプレビュー

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,6 +25,6 @@ require("config.autocmds")
 
 -- plugins (lua/plugins/*.lua を自動で集める)
 require("lazy").setup("plugins", {
-  install = { colorscheme = { "ayu" } },
+  install = { colorscheme = { "molokai" } },
   change_detection = { notify = false },
 })

--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,7 @@ vim.opt.rtp:prepend(lazypath)
 require("config.options")
 require("config.keymaps")
 require("config.autocmds")
+require("config.mermaid")
 
 -- plugins (lua/plugins/*.lua を自動で集める)
 require("lazy").setup("plugins", {

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -13,6 +13,7 @@
   "lazy.nvim": { "branch": "main", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
   "lexima.vim": { "branch": "master", "commit": "ab621e4756465c9d354fce88cff2bd1aa7887065" },
   "lightline.vim": { "branch": "master", "commit": "6c283f8df85aa7219fa4096a6ed4ff45d48aa9e1" },
+  "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "7b01e2974a47d489bb92f47a41e4c0088ea8f86e" },
   "mason.nvim": { "branch": "main", "commit": "16ba83bfc8a25f52bb545134f5bee082b195c460" },
   "nerdfont.vim": { "branch": "master", "commit": "0d1a98cb7917f5db1ed3ff773320aa1010a86859" },

--- a/lua/config/mermaid.lua
+++ b/lua/config/mermaid.lua
@@ -76,7 +76,7 @@ local function render()
         [[      if(nw<base.w/200||nw>base.w*200)return;var c=toUser(e.clientX,e.clientY);]],
         [[      vb.x=c.x-(c.x-vb.x)/f;vb.y=c.y-(c.y-vb.y)/f;vb.w/=f;vb.h/=f;set();}]],
         [[    else{var o=toUser(0,0),d=toUser(e.deltaX,e.deltaY);]],
-        [[      vb.x-=(d.x-o.x);vb.y-=(d.y-o.y);set();}},{passive:false});]],
+        [[      vb.x+=(d.x-o.x);vb.y+=(d.y-o.y);set();}},{passive:false});]],
         [[  var drag=false,lx=0,ly=0;]],
         [[  vp.addEventListener('pointerdown',function(e){drag=true;lx=e.clientX;ly=e.clientY;]],
         [[    vp.classList.add('drag');vp.setPointerCapture(e.pointerId);});]],

--- a/lua/config/mermaid.lua
+++ b/lua/config/mermaid.lua
@@ -1,0 +1,109 @@
+-- Mermaid (.mmd) のブラウザプレビュー。
+--
+-- .mmd では <leader>m で mmdc (mermaid-cli) を使い、最新 mermaid で SVG 化して
+-- ブラウザに表示する。markdown (.md) 側の <leader>m (markdown-preview.nvim) は
+-- ui.lua で別途定義されており、こちらとは独立 (filetype ごとのバッファローカル
+-- 割り当てなので、開いているファイルに応じて自動で振り分かる)。
+
+-- *.mmd / *.mermaid を mermaid filetype として認識させる
+vim.filetype.add({
+  extension = {
+    mmd = "mermaid",
+    mermaid = "mermaid",
+  },
+})
+
+-- mmdc (mermaid-cli) で現在の .mmd を SVG 化し、HTML に包んでブラウザで開く。
+--
+-- mkdp の同梱 mermaid は parse 失敗時に黙ってテキスト化するが、mmdc は最新の
+-- mermaid を使うため確実に描画でき、構文エラーは理由付きで報告される。
+local cache = vim.fn.stdpath("cache")
+local svg_path = cache .. "/mermaid-preview.svg"
+local html_path = cache .. "/mermaid-preview.html"
+
+local function render()
+  if vim.fn.executable("mmdc") == 0 then
+    vim.notify("mmdc (mermaid-cli) が見つかりません: brew install mermaid-cli", vim.log.levels.ERROR)
+    return
+  end
+
+  -- バッファ内容を一時 .mmd に書き出し (未保存・無名でも動くように)
+  local src_mmd = cache .. "/mermaid-preview.mmd"
+  vim.fn.writefile(vim.api.nvim_buf_get_lines(0, 0, -1, false), src_mmd)
+
+  vim.notify("mermaid: レンダリング中…", vim.log.levels.INFO)
+  vim.system(
+    { "mmdc", "-i", src_mmd, "-o", svg_path, "-b", "white" },
+    { text = true },
+    vim.schedule_wrap(function(out)
+      if out.code ~= 0 then
+        vim.notify("mermaid 描画失敗:\n" .. (out.stderr ~= "" and out.stderr or out.stdout), vim.log.levels.ERROR)
+        return
+      end
+      -- SVG をインラインし、Figma 風のホイールズーム/ドラッグパンを仕込んだ
+      -- HTML を生成する (CDN 不要・全てインライン)。
+      -- ズーム/パンは CSS transform ではなく SVG の viewBox を直接操作する。
+      -- transform:scale はラスタライズ後に拡大するためボケるが、viewBox 操作は
+      -- 都度ベクターを再描画するので何倍に拡大してもクッキリ保たれる。
+      local head = {
+        [[<!doctype html><meta charset="utf-8"><title>mermaid preview</title>]],
+        [[<style>]],
+        [[  html,body{margin:0;height:100%;overflow:hidden;background:#fff}]],
+        [[  #vp{width:100vw;height:100vh;overflow:hidden;cursor:grab}]],
+        [[  #vp.drag{cursor:grabbing}]],
+        [[  #vp>svg{display:block;width:100vw;height:100vh}]],
+        [[  #hint{position:fixed;bottom:8px;left:8px;font:12px -apple-system,sans-serif;]],
+        [[    color:#888;background:#ffffffcc;padding:4px 8px;border-radius:4px}]],
+        [[</style>]],
+        [[<div id="vp">]],
+      }
+      local tail = {
+        [[</div>]],
+        [[<div id="hint">scroll: パン ・ ⌘/⌃+scroll / ピンチ: ズーム ・ ドラッグ: パン ・ ダブルクリック: リセット</div>]],
+        [[<script>]],
+        [[(function(){]],
+        [[  var vp=document.getElementById('vp'),svg=vp.querySelector('svg');]],
+        [[  svg.removeAttribute('width');svg.removeAttribute('height');]],
+        [[  if(!svg.getAttribute('viewBox')){try{var b=svg.getBBox();]],
+        [[    svg.setAttribute('viewBox',b.x+' '+b.y+' '+b.width+' '+b.height);}catch(e){}}]],
+        [[  var p=svg.getAttribute('viewBox').split(/[ ,]+/).map(Number);]],
+        [[  var base={x:p[0],y:p[1],w:p[2],h:p[3]},vb={x:p[0],y:p[1],w:p[2],h:p[3]};]],
+        [[  function set(){svg.setAttribute('viewBox',vb.x+' '+vb.y+' '+vb.w+' '+vb.h);}]],
+        [[  function toUser(cx,cy){var pt=svg.createSVGPoint();pt.x=cx;pt.y=cy;]],
+        [[    return pt.matrixTransform(svg.getScreenCTM().inverse());}]],
+        [[  vp.addEventListener('wheel',function(e){e.preventDefault();]],
+        [[    if(e.metaKey||e.ctrlKey){var f=Math.exp(-e.deltaY*0.01),nw=vb.w/f;]],
+        [[      if(nw<base.w/200||nw>base.w*200)return;var c=toUser(e.clientX,e.clientY);]],
+        [[      vb.x=c.x-(c.x-vb.x)/f;vb.y=c.y-(c.y-vb.y)/f;vb.w/=f;vb.h/=f;set();}]],
+        [[    else{var o=toUser(0,0),d=toUser(e.deltaX,e.deltaY);]],
+        [[      vb.x-=(d.x-o.x);vb.y-=(d.y-o.y);set();}},{passive:false});]],
+        [[  var drag=false,lx=0,ly=0;]],
+        [[  vp.addEventListener('pointerdown',function(e){drag=true;lx=e.clientX;ly=e.clientY;]],
+        [[    vp.classList.add('drag');vp.setPointerCapture(e.pointerId);});]],
+        [[  vp.addEventListener('pointermove',function(e){if(!drag)return;]],
+        [[    var u1=toUser(lx,ly),u2=toUser(e.clientX,e.clientY);]],
+        [[    vb.x-=(u2.x-u1.x);vb.y-=(u2.y-u1.y);set();lx=e.clientX;ly=e.clientY;});]],
+        [[  vp.addEventListener('pointerup',function(){drag=false;vp.classList.remove('drag');});]],
+        [[  vp.addEventListener('dblclick',function(){vb={x:base.x,y:base.y,w:base.w,h:base.h};set();});]],
+        [[})();]],
+        [[</script>]],
+      }
+      local html = {}
+      vim.list_extend(html, head)
+      vim.list_extend(html, vim.fn.readfile(svg_path))
+      vim.list_extend(html, tail)
+      vim.fn.writefile(html, html_path)
+      vim.system({ "open", html_path })
+    end)
+  )
+end
+
+-- mermaid ファイルで <leader>m に mmdc 描画を割り当て
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "mermaid",
+  callback = function(args)
+    vim.keymap.set("n", "<leader>m", render, {
+      buffer = args.buf, silent = true, desc = "Mermaid Render (mmdc / browser)",
+    })
+  end,
+})

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -17,8 +17,11 @@ vim.opt.incsearch = true
 vim.opt.background = "dark"
 vim.opt.cursorline = true
 vim.opt.termguicolors = true
-vim.g.ayucolor = "light"
-vim.cmd("colorscheme ayu")
+vim.cmd("colorscheme molokai")
+-- molokai は treesitter 以前のテーマで @variable 未定義のため、放置すると
+-- Neovim 組み込みデフォルトの薄グレーにフォールバックして見づらい。
+-- monokai 流儀どおり変数は地の白 (#F8F8F2) にする。
+vim.api.nvim_set_hl(0, "@variable", { fg = "#F8F8F2" })
 vim.opt.laststatus = 2
 vim.opt.updatetime = 2000
 

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -1,3 +1,7 @@
+-- leader はプラグイン (lazy keys) ロード前に確定させる必要があるため最初に設定
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
 vim.cmd("filetype plugin on")
 vim.cmd("lang en_US.UTF-8")
 

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -4,11 +4,11 @@ return {
   cmd = "Telescope",
   dependencies = { "nvim-lua/plenary.nvim" },
   keys = {
-    { "ff", "<cmd>Telescope find_files<CR>" },
-    { "fw", "<cmd>Telescope live_grep<CR>" },
-    { "fb", "<cmd>Telescope buffers<CR>" },
-    { "fh", "<cmd>Telescope help_tags<CR>" },
-    { "fg", "<cmd>Telescope git_files<CR>" },
+    { "<leader>ff", "<cmd>Telescope find_files<CR>", desc = "Find files" },
+    { "<leader>fw", "<cmd>Telescope live_grep<CR>", desc = "Live grep" },
+    { "<leader>fb", "<cmd>Telescope buffers<CR>", desc = "Buffers" },
+    { "<leader>fh", "<cmd>Telescope help_tags<CR>", desc = "Help tags" },
+    { "<leader>fg", "<cmd>Telescope git_files<CR>", desc = "Git files" },
   },
   config = function()
     local actions = require("telescope.actions")

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -46,6 +46,28 @@ return {
   },
 
   {
+    -- バッファ内描画 (render-markdown) では折り返せない広いテーブル等を
+    -- ブラウザで確認するための preview。<leader>m でトグル。
+    "iamcco/markdown-preview.nvim",
+    ft = { "markdown" },
+    build = function()
+      vim.fn["mkdp#util#install"]()
+    end,
+    init = function()
+      vim.g.mkdp_auto_close = 0 -- バッファ移動で勝手に閉じない
+      vim.g.mkdp_theme = "dark"
+    end,
+    keys = {
+      {
+        "<leader>m",
+        "<cmd>MarkdownPreviewToggle<cr>",
+        ft = "markdown",
+        desc = "Markdown Preview Toggle",
+      },
+    },
+  },
+
+  {
     "airblade/vim-gitgutter",
     event = "BufReadPre",
     config = function()

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -4,7 +4,7 @@ return {
     lazy = false,
     init = function()
       vim.g.lightline = {
-        colorscheme = "solarized",
+        colorscheme = "molokai",
         active = {
           left = {
             { "mode", "paste" },
@@ -53,27 +53,8 @@ return {
       vim.keymap.set("", "gh", "<cmd>GitGutterLineHighlightsToggle<CR>", opts)
       vim.keymap.set("", "gp", "<cmd>GitGutterPreviewHunk<CR>", opts)
       vim.keymap.set("", "gf", "<cmd>GitGutterDiffOrig<CR>", opts)
-
-      vim.cmd([[
-        highlight GitGutterAdd ctermfg=green
-        highlight GitGutterChange ctermfg=blue
-        highlight GitGutterDelete ctermfg=red
-
-        highlight GitGutterAddLine ctermbg=green
-        highlight GitGutterChangeLine ctermbg=blue
-        highlight GitGutterDeleteLine ctermbg=red
-
-        highlight GitGutterAddLineNr ctermbg=green
-        highlight GitGutterChangeLineNr ctermbg=blue
-        highlight GitGutterDeleteLineNr ctermbg=red
-
-        highlight diffAdd ctermbg=green
-        highlight diffChange ctermbg=blue
-        highlight diffRemove ctermbg=red
-        highlight diffAdd ctermfg=black
-        highlight diffChange ctermfg=yellow
-        highlight diffRemove ctermfg=yellow
-      ]])
+      -- 色は ayu.vim の GitGutter*/Diff* 定義に任せる
+      -- (旧 cterm 指定は termguicolors 下では無効だったため削除)
     end,
   },
 }


### PR DESCRIPTION
## 概要

`.mmd` (Mermaid) ファイルを `<leader>m` でブラウザにレンダリング表示できるようにした。

## 変更点

- `*.mmd` / `*.mermaid` を `mermaid` filetype として認識
- `<leader>m` で **mermaid-cli (`mmdc`)** により最新 mermaid で SVG 化し、ブラウザで開く
  - ビューアは **SVG の viewBox 操作**でズーム/パン (Figma 風) — ベクターのまま拡大してもクッキリ
  - 操作: 2本指スクロール=パン / ⌘・⌃+スクロール・ピンチ=ズーム / ドラッグ=パン / ダブルクリック=リセット
  - CDN 不要・全てインライン HTML
- markdown-preview.nvim (mkdp) は parse 失敗時に黙ってテキスト化するため不採用。`mmdc` は構文エラーを理由付きで通知する
- markdown (`.md`) 側の `<leader>m` (markdown-preview.nvim, `ui.lua`) は独立。filetype ごとのバッファローカル割り当てで自動振り分け

## 前提

- `mmdc` (mermaid-cli) がインストール済みであること (`brew install mermaid-cli` 済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)